### PR TITLE
PasswordInputにerror要素を追加するのを忘れていたので修正

### DIFF
--- a/src/components/ui/form/PasswordInput.tsx
+++ b/src/components/ui/form/PasswordInput.tsx
@@ -21,6 +21,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({ label = "パスワード"
         label={label}
         helperText={error ? helperText : ''}
         placeholder={placeholder}
+        error={error}
         value={value}
         type={showPassword ? 'text' : 'password'}
         onChange={onChange}


### PR DESCRIPTION
errorを入れ忘れたことで、エラー時にフォームが赤くならないという問題が発生していたので修正しました。